### PR TITLE
fast-glob>3.0.0 doesn't support backslashes as path separator, fix it by normalize the path

### DIFF
--- a/src/steps/getFilesToProcess.ts
+++ b/src/steps/getFilesToProcess.ts
@@ -1,8 +1,11 @@
-import {resolve} from "path";
-import {sync} from "fast-glob";
+import { resolve } from "path";
+import { sync } from "fast-glob";
 
 function convertPath(windowsPath: string) {
-    return windowsPath.replace(/^\\\\\?\\/, "").replace(/\\/g, '\/').replace(/\/\/+/g, '\/');
+  return windowsPath
+    .replace(/^\\\\\?\\/, "")
+    .replace(/\\/g, "/")
+    .replace(/\/\/+/g, "/");
 }
 
 /**
@@ -12,15 +15,15 @@ function convertPath(windowsPath: string) {
  * @param extensions A comma separated list of extensions to match.
  */
 export function getFilesToProcess(outPath: string, extensions: string) {
-    const normalizedOutPath = convertPath(outPath);
-    const extensionsList = extensions.split(",");
+  const normalizedOutPath = convertPath(outPath);
+  const extensionsList = extensions.split(",");
 
-    let glob = "*";
-    if (extensionsList.length === 1) glob = `*.${extensionsList[0]}`;
-    else if (extensionsList.length > 1) glob = `*.{${extensionsList.join(",")}}`;
+  let glob = "*";
+  if (extensionsList.length === 1) glob = `*.${extensionsList[0]}`;
+  else if (extensionsList.length > 1) glob = `*.{${extensionsList.join(",")}}`;
 
-    return sync(`${normalizedOutPath}/**/${glob}`, {
-        dot: true,
-        onlyFiles: true,
-    }).map((path) => resolve(path));
+  return sync(`${normalizedOutPath}/**/${glob}`, {
+    dot: true,
+    onlyFiles: true,
+  }).map((path) => resolve(path));
 }

--- a/src/steps/getFilesToProcess.ts
+++ b/src/steps/getFilesToProcess.ts
@@ -1,5 +1,9 @@
-import { resolve } from "path";
-import { sync } from "fast-glob";
+import {resolve} from "path";
+import {sync} from "fast-glob";
+
+function convertPath(windowsPath: string) {
+    return windowsPath.replace(/^\\\\\?\\/, "").replace(/\\/g, '\/').replace(/\/\/+/g, '\/');
+}
 
 /**
  * Get the files in the output directory that should be processed.
@@ -8,14 +12,15 @@ import { sync } from "fast-glob";
  * @param extensions A comma separated list of extensions to match.
  */
 export function getFilesToProcess(outPath: string, extensions: string) {
-  const extensionsList = extensions.split(",");
+    const normalizedOutPath = convertPath(outPath);
+    const extensionsList = extensions.split(",");
 
-  let glob = "*";
-  if (extensionsList.length === 1) glob = `*.${extensionsList[0]}`;
-  else if (extensionsList.length > 1) glob = `*.{${extensionsList.join(",")}}`;
+    let glob = "*";
+    if (extensionsList.length === 1) glob = `*.${extensionsList[0]}`;
+    else if (extensionsList.length > 1) glob = `*.{${extensionsList.join(",")}}`;
 
-  return sync(`${outPath}/**/${glob}`, {
-    dot: true,
-    onlyFiles: true,
-  }).map((path) => resolve(path));
+    return sync(`${normalizedOutPath}/**/${glob}`, {
+        dot: true,
+        onlyFiles: true,
+    }).map((path) => resolve(path));
 }

--- a/test/steps/getFilesToProcess.test.ts
+++ b/test/steps/getFilesToProcess.test.ts
@@ -1,18 +1,26 @@
-import { getFilesToProcess } from "~/steps/getFilesToProcess";
+import {getFilesToProcess} from "~/steps/getFilesToProcess";
+import * as path from "path";
 
 describe("steps/getFilesToProcess", () => {
   it("gets files with one extension correctly", () => {
-    const files = getFilesToProcess("test/fixtures/files", "js");
+    // absolute path is passed to getFilesToProcess function, so we have to convert it
+    const cwd = process.cwd();
+    const testDirectory = path.join(cwd, "test/fixtures/files");
+    const files = getFilesToProcess(testDirectory, "js");
     expect(files).toHaveLength(1);
   });
 
   it("gets files with multiple extensions correctly", () => {
-    const files = getFilesToProcess("test/fixtures/files", "js,ts");
+    const cwd = process.cwd();
+    const testDirectory = path.join(cwd, "test/fixtures/files");
+    const files = getFilesToProcess(testDirectory, "js,ts");
     expect(files).toHaveLength(2);
   });
 
   it("gets nested files correctly", () => {
-    const files = getFilesToProcess("test/fixtures/files", "tsx");
+    const cwd = process.cwd();
+    const testDirectory = path.join(cwd, "test/fixtures/files");
+    const files = getFilesToProcess(testDirectory, "tsx");
     expect(files).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Hello,
        The fast-glob package since 3.0.0 does not support backslashes as path separator. So i fix it by normalizing the path. I also change the test file so it can correctly detect this problem on windows platform. 