### PR TITLE
Resolve match-all glob pattern ("*") correctly

### DIFF
--- a/src/steps/computeAliases.ts
+++ b/src/steps/computeAliases.ts
@@ -15,7 +15,6 @@ export function computeAliases(basePath: string, tsConfig: TSConfig): Alias[] {
       aliasPaths: paths[alias].map((path: string) =>
         resolve(basePath, path.replace(regex, ""))
       ),
-    }))
-    .filter(({ prefix }) => prefix);
+    }));
   return aliases;
 }

--- a/test/steps/computeAliases.test.ts
+++ b/test/steps/computeAliases.test.ts
@@ -5,18 +5,21 @@ describe("steps/computeAliases", () => {
     const aliases = computeAliases(".", {
       compilerOptions: {
         paths: {
+          "*": ["./lib/*"],
           "~/*": ["./src/*", "./root/*"],
           "@app": ["./src/app/*"],
         },
       },
     });
 
-    expect(aliases).toHaveLength(2);
-    expect(aliases[0].prefix).toEqual("~/");
-    expect(aliases[1].prefix).toEqual("@app");
+    expect(aliases).toHaveLength(3);
+    expect(aliases[0].prefix).toEqual("");
+    expect(aliases[1].prefix).toEqual("~/");
+    expect(aliases[2].prefix).toEqual("@app");
 
     const cwd = process.cwd();
-    expect(aliases[0].aliasPaths).toEqual([`${cwd}/src`, `${cwd}/root`]);
-    expect(aliases[1].aliasPaths).toEqual([`${cwd}/src/app`]);
+    expect(aliases[0].aliasPaths).toEqual([`${cwd}/lib`]);
+    expect(aliases[1].aliasPaths).toEqual([`${cwd}/src`, `${cwd}/root`]);
+    expect(aliases[2].aliasPaths).toEqual([`${cwd}/src/app`]);
   });
 });


### PR DESCRIPTION
Consider the following valid `tsconfig.json` snippet:

```
{
    "compilerOptions": {
        "paths": {
            "*": ["src/*"]
        }
    }
}
```

Configurations such as this are commonly used to resolve local modules as if they were in `node_modules` (i.e. directly, with no prefix), and are well supported in tsc. However, such mappings were being filtered from the list of aliases resulting in incorrect resolution.

This PR removes that filtering and allows for correct behavior under these settings.

I have tested the changes locally on multiple medium-sized projects and also included a test-case.

From a technical perspective, I don't see why this would cause issues other than potential name clashes, which are inherent to this mapping (and both equally present in tsc and easy to circumvent). If I am missing something, please let me know.

Thank you for your time and consideration.