### PR TITLE
feat: add support for require.resolve statements (#119)

### DIFF
--- a/src/steps/generateChanges.ts
+++ b/src/steps/generateChanges.ts
@@ -6,7 +6,7 @@ import { FileNotFoundError } from "~/utils/errors";
 import type { Alias, Change, ProgramPaths, TextChange } from "~/types";
 
 export const IMPORT_EXPORT_REGEX =
-  /(?:(?:require\(|import\()|(?:import|export) (?:.*from )?)['"]([^'"]*)['"]\)?/g;
+  /(?:(?:require\(|require\.resolve\(|import\()|(?:import|export) (?:.*from )?)['"]([^'"]*)['"]\)?/g;
 
 const PATHS = [
   ".js",

--- a/test/steps/generateChanges.test.ts
+++ b/test/steps/generateChanges.test.ts
@@ -128,6 +128,18 @@ describe("steps/generateChanges", () => {
       `);
     });
 
+    it("matches const require.resolve statements", () => {
+      const result = regex.exec(
+        `const package = require.resolve('../package');`
+      );
+      expect(result).toMatchInlineSnapshot(`
+        Array [
+          "require.resolve('../package')",
+          "../package",
+        ]
+      `);
+    });
+
     it("matches const {} require statements", () => {
       const result = regex.exec(
         `const { package } = require('~/package/package');`


### PR DESCRIPTION
Adds support for [require.resolve](https://nodejs.org/api/modules.html#requireresolverequest-options) statements.

Thanks to @wintercounter for the request (closes #119).