### PR TITLE
fix: Broken replacement when export and file contain the same string

### DIFF
--- a/src/steps/generateChanges.ts
+++ b/src/steps/generateChanges.ts
@@ -88,7 +88,7 @@ export function replaceAliasPathsInFile(
 
       if (!result.replacement) return original;
 
-      const index = original.indexOf(matched);
+      const index = original.lastIndexOf(matched);
       changes.push({
         original: result.original,
         modified: result.replacement,

--- a/test/fixtures/sameNameTest/out/reexportSameName.d.ts
+++ b/test/fixtures/sameNameTest/out/reexportSameName.d.ts
@@ -1,0 +1,1 @@
+export { sameName } from "sameName";

--- a/test/fixtures/sameNameTest/out/reexportSameName.js
+++ b/test/fixtures/sameNameTest/out/reexportSameName.js
@@ -1,0 +1,16 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+exports.__esModule = true;
+exports.sameName = void 0;
+var sameName_1 = require("sameName");
+__createBinding(exports, sameName_1, "sameName");

--- a/test/fixtures/sameNameTest/out/sameName.d.ts
+++ b/test/fixtures/sameNameTest/out/sameName.d.ts
@@ -1,0 +1,1 @@
+export declare const sameName = "Something";

--- a/test/fixtures/sameNameTest/out/sameName.js
+++ b/test/fixtures/sameNameTest/out/sameName.js
@@ -1,0 +1,4 @@
+"use strict";
+exports.__esModule = true;
+exports.sameName = void 0;
+exports.sameName = "Something";

--- a/test/fixtures/sameNameTest/src/reexportSameName.ts
+++ b/test/fixtures/sameNameTest/src/reexportSameName.ts
@@ -1,0 +1,1 @@
+export {sameName} from "sameName";

--- a/test/fixtures/sameNameTest/src/sameName.ts
+++ b/test/fixtures/sameNameTest/src/sameName.ts
@@ -1,0 +1,1 @@
+export const sameName = "Something";

--- a/test/fixtures/sameNameTest/tsconfig.json
+++ b/test/fixtures/sameNameTest/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+      "outDir": "./out",
+      "baseUrl": ".",
+      "declaration": true,
+      "paths": {
+        "*": ["./src/*"]
+      }
+    }
+  }
+  

--- a/test/steps/generateChanges.test.ts
+++ b/test/steps/generateChanges.test.ts
@@ -633,6 +633,40 @@ describe("steps/generateChanges", () => {
           "
         `);
       });
+
+      it("replaces exports with the same name as the path correctly", () => {
+        const root = `${cwd}/test/fixtures/sameNameTest`;
+        const aliases: Alias[] = [
+          {
+            alias: "*",
+            prefix: "",
+            aliasPaths: [`${root}/src`],
+          },
+        ];
+        const programPaths: Pick<ProgramPaths, "srcPath" | "outPath"> = {
+          srcPath: `${root}/src`,
+          outPath: `${root}/out`,
+        };
+        const results = replaceAliasPathsInFile(
+          `${root}/out/reexportSameName.d.ts`,
+          aliases,
+          programPaths
+        );
+        expect(results.changed).toBe(true);
+        expect(results.changes).toHaveLength(1);
+        expect(results.changes).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "modified": "./sameName",
+              "original": "sameName",
+            },
+          ]
+        `);
+        expect(results.text).not.toContain(
+          'export { ./sameName } from "sameName"'
+        );
+        expect(results.text).toContain('export { sameName } from "./sameName"');
+      });
     });
   });
 


### PR DESCRIPTION
fixes #151 by replacing the last occurrence of the matched filename instead of the first one.

Also I added a test for the bug, but was not sure where to place the fixture as it has a different typescript config to the other tests.