### PR TITLE
fix: Add better support for jsx files

### DIFF
--- a/src/steps/generateChanges.ts
+++ b/src/steps/generateChanges.ts
@@ -199,7 +199,7 @@ export function aliasToRelativePath(
  * @param importPath An non-relative import path
  */
 function resolveImportPath(importPath: string) {
-  const importPathTs = importPath.replace(/\.[^.]*js[^.]*$/, (match) =>
+  const importPathTs = importPath.replace(/\.[^/.]*js[^/.]*$/, (match) =>
     match.replace("js", "ts")
   );
   const importPathWithExtensions = MODULE_EXTS.map(

--- a/src/steps/generateChanges.ts
+++ b/src/steps/generateChanges.ts
@@ -126,6 +126,7 @@ export function aliasToRelativePath(
 ): { file: string; original: string; replacement?: string } {
   const sourceFile = resolve(srcPath, relative(outPath, outputFile));
   const sourceFileDirectory = dirname(sourceFile);
+  const outputFileDirectory = dirname(outputFile);
 
   const importPathIsRelative =
     importSpecifier.startsWith("./") || importSpecifier.startsWith("../");
@@ -170,16 +171,24 @@ export function aliasToRelativePath(
     (m) => "./" + m
   );
 
-  const extensionFixedRelativePath = prefixedRelativePath.replace(
+  const relativePathJsExtension = prefixedRelativePath.replace(
     /\.[^/.]*ts[^/.]*$/,
     (match) => match.replace("ts", "js")
+  );
+
+  const relativePathJsxExtension = relativePathJsExtension.replace(
+    /\.jsx$/,
+    (match) =>
+      isFile(resolve(outputFileDirectory, relativePathJsExtension))
+        ? match
+        : ".js"
   );
 
   return {
     file: outputFile,
     original: importSpecifier,
-    ...(importSpecifier !== extensionFixedRelativePath
-      ? { replacement: extensionFixedRelativePath }
+    ...(importSpecifier !== relativePathJsxExtension
+      ? { replacement: relativePathJsxExtension }
       : {}),
   };
 }

--- a/test/fixtures/reactExtensions/out/WithJsxPreserve.jsx
+++ b/test/fixtures/reactExtensions/out/WithJsxPreserve.jsx
@@ -1,0 +1,1 @@
+export const WithJsxPreserve = () => <div>content</div>

--- a/test/fixtures/reactExtensions/out/WithJsxReact.js
+++ b/test/fixtures/reactExtensions/out/WithJsxReact.js
@@ -1,0 +1,2 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+export const WithJsxReact = () => <div>content</div>

--- a/test/fixtures/reactExtensions/out/index.js
+++ b/test/fixtures/reactExtensions/out/index.js
@@ -1,0 +1,2 @@
+export { WithJsxPreserve } from "~/WithJsxPreserve";
+export { WithJsxReact } from "~/WithJsxReact";

--- a/test/fixtures/reactExtensions/src/WithJsxPreserve.tsx
+++ b/test/fixtures/reactExtensions/src/WithJsxPreserve.tsx
@@ -1,0 +1,1 @@
+export const WithJsxPreserve = () => <div>content</div>

--- a/test/fixtures/reactExtensions/src/WithJsxReact.tsx
+++ b/test/fixtures/reactExtensions/src/WithJsxReact.tsx
@@ -1,0 +1,1 @@
+export const WithJsxPreserve = () => <div>content</div>

--- a/test/fixtures/reactExtensions/src/index.ts
+++ b/test/fixtures/reactExtensions/src/index.ts
@@ -1,0 +1,2 @@
+export { WithJsxPreserve } from "~/WithJsxPreserve";
+export { WithJsxReact } from "~/WithJsxReact";

--- a/test/steps/generateChanges.test.ts
+++ b/test/steps/generateChanges.test.ts
@@ -765,6 +765,33 @@ describe("steps/generateChanges", () => {
         expect(results.text).toContain(`export * as delta from "./delta.mjs"`);
         expect(results.text).toContain(`export { value } from "./test.json"`);
       });
+
+      it("imports work with jsx files in different modes", () => {
+        const root = `${cwd}/test/fixtures/reactExtensions`;
+        const aliases: Alias[] = [
+          {
+            alias: "~/*",
+            prefix: "~/",
+            aliasPaths: [`${root}/src`],
+          },
+        ];
+        const programPaths: Pick<ProgramPaths, "srcPath" | "outPath"> = {
+          srcPath: `${root}/src`,
+          outPath: `${root}/out`,
+        };
+        const results = replaceAliasPathsInFile(
+          `${root}/out/index.js`,
+          aliases,
+          programPaths
+        );
+        expect(results.changed).toBe(true);
+        expect(results.text).toContain(
+          `export { WithJsxPreserve } from "./WithJsxPreserve.jsx"`
+        );
+        expect(results.text).toContain(
+          `export { WithJsxReact } from "./WithJsxReact.js"`
+        );
+      });
     });
 
     describe("esm", () => {


### PR DESCRIPTION
TypeScript transforms react jsx files (ending with `.tsx`) to `.jsx` or `.js` files depending on the [`jsx` setting](https://www.typescriptlang.org/tsconfig#jsx) in tsconfig.

This PR adjusts our resolution algorithm to fall back to a `.js` file if there is no matching `.jsx` file in the output files.