### PR TITLE
fix: paths on Windows

### DIFF
--- a/src/steps/computeAliases.ts
+++ b/src/steps/computeAliases.ts
@@ -1,7 +1,11 @@
-import { resolve } from "path";
+import { resolve as resolveRaw } from "path";
 
 import type { Alias } from "~/types";
 import { InvalidAliasError } from "~/utils/errors";
+
+function resolve(...pathSegments: string[]): string {
+  return resolveRaw(...pathSegments).replace(/\\/g, "/");
+}
 
 /**
  * Compute the alias paths provided by the tsconfig.

--- a/src/steps/generateChanges.ts
+++ b/src/steps/generateChanges.ts
@@ -1,5 +1,11 @@
 import { existsSync, readFileSync, statSync } from "fs";
-import { basename, dirname, join, relative, resolve } from "path";
+import {
+  basename,
+  dirname,
+  join as joinRaw,
+  relative as relativeRaw,
+  resolve as resolveRaw,
+} from "path";
 
 import { FileNotFoundError } from "~/utils/errors";
 
@@ -24,6 +30,18 @@ const MODULE_EXTS = [
   ".mdx",
   ".d.ts",
 ];
+
+function relative(from: string, to: string): string {
+  return relativeRaw(from, to).replace(/\\/g, "/");
+}
+
+function resolve(...pathSegments: string[]): string {
+  return resolveRaw(...pathSegments).replace(/\\/g, "/");
+}
+
+function join(...pathSegments: string[]): string {
+  return joinRaw(...pathSegments).replace(/\\/g, "/");
+}
 
 /**
  * Generate the alias path mapping changes to apply to the provide files.

--- a/test/steps/computeAliases.test.ts
+++ b/test/steps/computeAliases.test.ts
@@ -16,7 +16,7 @@ describe("steps/computeAliases", () => {
     expect(aliases[1].prefix).toEqual("~/");
     expect(aliases[2].prefix).toEqual("@app");
 
-    const cwd = process.cwd();
+    const cwd = process.cwd().replace(/\\/g, "/");
     expect(aliases[0].aliasPaths).toEqual([`${cwd}/lib`]);
     expect(aliases[1].aliasPaths).toEqual([`${cwd}/src`, `${cwd}/root`]);
     expect(aliases[2].aliasPaths).toEqual([`${cwd}/src/app`]);
@@ -34,7 +34,7 @@ describe("steps/computeAliases", () => {
     expect(aliases[1].prefix).toEqual("~/");
     expect(aliases[2].prefix).toEqual("@app");
 
-    const cwd = process.cwd();
+    const cwd = process.cwd().replace(/\\/g, "/");
     expect(aliases[0].aliasPaths).toEqual([`${cwd}/lib`]);
     expect(aliases[1].aliasPaths).toEqual([`${cwd}/src`, `${cwd}/root`]);
     expect(aliases[2].aliasPaths).toEqual([`${cwd}/src/app`]);


### PR DESCRIPTION
On Windows, imports got resolved like `require("./..\..\shared\src\index.js");` which obviously is incorrect syntax.

Remap all path operations so that they use forward slashes, for more compatibility.

This also makes all tests pass successfully on Windows.