### PR TITLE
fix import and export regex

### DIFF
--- a/src/steps/generateChanges.ts
+++ b/src/steps/generateChanges.ts
@@ -7,10 +7,10 @@ import { normalizePath } from "~/utils/path";
 import type { Alias, Change, ProgramPaths, TextChange } from "~/types";
 
 export const IMPORT_EXPORT_REGEX =
-  /((?:require\(|require\.resolve\(|import\()|(?:import|export) (?:.*from )?)['"]([^'"]*)['"]\)?/g;
+  /((?:require\(|require\.resolve\(|import\()|(?:import|export)\s+(?:[\s\S]*?from\s+)?)['"]([^'"]*)['"]\)?/g;
 
 export const ESM_IMPORT_EXPORT_REGEX =
-  /(?:(?:import\()|(?:import|export)\s+(?:.*from\s+)?)['"]([^'"]*)['"]\)?/g;
+  /(?:(?:import\()|(?:import|export)\s+(?:[\s\S]*?from\s+)?)['"]([^'"]*)['"]\)?/g
 
 export const COMMONJS_IMPORT_EXPORT_REGEX =
   /(?:(?:require\(|require\.resolve\()\s+)['"]([^'"]*)['"]\)/g;

--- a/test/steps/generateChanges.test.ts
+++ b/test/steps/generateChanges.test.ts
@@ -62,6 +62,26 @@ describe("steps/generateChanges", () => {
       `);
     });
 
+    it("matches import statements with multiple named imports", () => {
+      const result = regex.exec(`import {
+  package as myPackage,
+  otherPackage,
+} from '../package';`);
+      expect(result).toMatchInlineSnapshot(`
+        [
+          "import {
+          package as myPackage,
+          otherPackage,
+        } from '../package'",
+          "import {
+          package as myPackage,
+          otherPackage,
+        } from ",
+          "../package",
+        ]
+      `);
+    })
+
     it("matches export * statements", () => {
       const result = regex.exec(`export * from 'package';`);
       expect(result).toMatchInlineSnapshot(`
@@ -118,6 +138,26 @@ describe("steps/generateChanges", () => {
         ]
       `);
     });
+
+    it("matches import statements with multiple named imports", () => {
+      const result = regex.exec(`export {
+  package as myPackage,
+  otherPackage,
+} from '../package';`);
+      expect(result).toMatchInlineSnapshot(`
+        [
+          "export {
+          package as myPackage,
+          otherPackage,
+        } from '../package'",
+          "export {
+          package as myPackage,
+          otherPackage,
+        } from ",
+          "../package",
+        ]
+      `);
+    })
 
     it("matches require statements", () => {
       const result = regex.exec(`require('package');`);


### PR DESCRIPTION
The previous regex did not correctly match newlines, but the updated regex ensures accurate matching of whitespace, including newlines.
This modification enables matching of import statements like the following:

```
import {
  A,
  B
} from "test"
```